### PR TITLE
Fix crash when guest connect is typed with capitalization

### DIFF
--- a/plugins/login/commands/connect_cmd.rb
+++ b/plugins/login/commands/connect_cmd.rb
@@ -27,7 +27,7 @@ module AresMUSH
       def handle
         # Should not get here based on prior checks
         if self.charname.downcase == "guest"
-          raise "Ended up in connect handlef as guest"
+          raise "Ended up in connect handler as guest"
         end
 
         ClassTargetFinder.with_a_character(self.charname, client, enactor) do |char|

--- a/plugins/login/login.rb
+++ b/plugins/login/login.rb
@@ -32,7 +32,7 @@ module AresMUSH
       when "boot"
         return BootCmd
       when "connect"
-        if (cmd.args && cmd.args.start_with?("guest"))
+        if (cmd.args && cmd.args.downcase.start_with?("guest"))
           return TourCmd
         else
           return ConnectCmd
@@ -115,7 +115,7 @@ module AresMUSH
       # Special check to allow 'c' to be used for tour or connect when not logged in.
       if (!client.logged_in?)
         if (cmd.args && (cmd.root_is?("c") || cmd.root_is?("co")))
-          if (cmd.args.start_with?("guest"))
+          if (cmd.args.downcase.start_with?("guest"))
             return TourCmd
           else
             return ConnectCmd


### PR DESCRIPTION
## Summary

Typing `connect Guest` or `co Guest` (capital G) at the login screen crashes with an internal error instead of connecting the player to a tour character:

```
%% Sorry! The code lost its mind while executing a command.  Not your fault.
Description: "co Guest"
Error: "Ended up in connect handlef as guest"
```

Lowercase `connect guest` works fine.

## Cause

The dispatcher in `plugins/login/login.rb` routes guest connects to `TourCmd` with a **case-sensitive** check (`cmd.args.start_with?("guest")`), but the safety guard in `ConnectCmd` is **case-insensitive** (`self.charname.downcase == "guest"`). A capitalized guest name falls through the routing to `ConnectCmd` and trips the guard's raise, which surfaces to the player as the error above. Since new players plausibly type names capitalized, this is an easy crash to hit on any stock game.

## Fix

Downcase the args in the two routing checks so any capitalization reaches `TourCmd`, and fix the "handlef" typo in the guard's error message.

Verified on a live game: `connect Guest` and `co Guest` now connect to a temp tour character, and `connect <name>` for regular characters is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)